### PR TITLE
Added z-value to tilePoint to make it compatible with Leaflet 0.6

### DIFF
--- a/src/BoundaryCanvas.js
+++ b/src/BoundaryCanvas.js
@@ -215,7 +215,8 @@
         imageObj.onload = function () {
             setTimeout(setPattern, 0); //IE9 bug - black tiles appear randomly if call setPattern() without timeout
         }
-        imageObj.src = this.getTileUrl(tilePoint, zoom);
+		this._adjustTilePoint(tilePoint);
+        imageObj.src = this.getTileUrl(tilePoint);
 	}
 });
 


### PR DESCRIPTION
tilePoint needs a Z-value from 0.6 onwards. This shouldn't break compatibility with 0.5.
